### PR TITLE
Replace deprecated container and inventory APIs [UPDATE 4]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+### Gradle ###
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### Hytale ###
+run/
+hytaleServer/
+libs/
+
+### IntelliJ IDEA ###
+.idea/
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/src/main/java/net/conczin/LecternInteraction.java
+++ b/src/main/java/net/conczin/LecternInteraction.java
@@ -11,6 +11,7 @@ import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.asset.type.soundevent.config.SoundEvent;
 import com.hypixel.hytale.server.core.entity.InteractionContext;
 import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.server.core.inventory.InventoryComponent;
 import com.hypixel.hytale.server.core.entity.entities.player.pages.CustomUIPage;
 import com.hypixel.hytale.server.core.entity.entities.player.pages.PageManager;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
@@ -88,11 +89,13 @@ public class LecternInteraction extends SimpleBlockInteraction {
         } else {
             if (bookInLectern == null) {
                 // Place book in the lectern
-                byte activeHotbarSlot = player.getInventory().getActiveHotbarSlot();
+                InventoryComponent.Hotbar hotbar = Utils.getHotbar(ref);
+                if (hotbar == null) return;
+                byte activeHotbarSlot = hotbar.getActiveSlot();
                 ItemContainerBlock inventoryState = Utils.getInventory(world, targetBlock);
                 if (inventoryState == null) return;
                 ItemContainer inventory = inventoryState.getItemContainer();
-                if (inventory != null && player.getInventory().getHotbar().moveItemStackFromSlot(activeHotbarSlot, inventory).succeeded()) {
+                if (inventory != null && hotbar.getInventory().moveItemStackFromSlot(activeHotbarSlot, inventory).succeeded()) {
                     playSound(commandBuffer, targetPosition, ref, "SFX_Books_And_Papers_Place");
                 }
             } else {

--- a/src/main/java/net/conczin/LecternInteraction.java
+++ b/src/main/java/net/conczin/LecternInteraction.java
@@ -15,12 +15,12 @@ import com.hypixel.hytale.server.core.entity.entities.player.pages.CustomUIPage;
 import com.hypixel.hytale.server.core.entity.entities.player.pages.PageManager;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
 import com.hypixel.hytale.server.core.inventory.container.ItemContainer;
+import com.hypixel.hytale.server.core.modules.block.components.ItemContainerBlock;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.CooldownHandler;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.client.SimpleBlockInteraction;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import com.hypixel.hytale.server.core.universe.world.SoundUtil;
 import com.hypixel.hytale.server.core.universe.world.World;
-import com.hypixel.hytale.server.core.universe.world.meta.state.ItemContainerState;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
 import net.conczin.data.BookData;
 import net.conczin.gui.BookUISupplier;
@@ -89,7 +89,7 @@ public class LecternInteraction extends SimpleBlockInteraction {
             if (bookInLectern == null) {
                 // Place book in the lectern
                 byte activeHotbarSlot = player.getInventory().getActiveHotbarSlot();
-                ItemContainerState inventoryState = Utils.getInventory(world, targetBlock);
+                ItemContainerBlock inventoryState = Utils.getInventory(world, targetBlock);
                 if (inventoryState == null) return;
                 ItemContainer inventory = inventoryState.getItemContainer();
                 if (inventory != null && player.getInventory().getHotbar().moveItemStackFromSlot(activeHotbarSlot, inventory).succeeded()) {

--- a/src/main/java/net/conczin/MailboxInteraction.java
+++ b/src/main/java/net/conczin/MailboxInteraction.java
@@ -10,6 +10,7 @@ import com.hypixel.hytale.server.core.Message;
 import com.hypixel.hytale.server.core.asset.type.soundevent.config.SoundEvent;
 import com.hypixel.hytale.server.core.entity.InteractionContext;
 import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.server.core.inventory.InventoryComponent;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
 import com.hypixel.hytale.server.core.inventory.container.SimpleItemContainer;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.CooldownHandler;
@@ -65,7 +66,7 @@ public class MailboxInteraction extends SimpleBlockInteraction {
                 if (mailbox.hasMail()) {
                     ItemStack pop = mailbox.pop();
                     if (pop != null) {
-                        SimpleItemContainer.addOrDropItemStacks(store, ref, player.getInventory().getCombinedHotbarFirst(), List.of(pop));
+                        SimpleItemContainer.addOrDropItemStacks(store, ref, InventoryComponent.getCombined(store, ref, InventoryComponent.HOTBAR_FIRST), List.of(pop));
                         playSound(commandBuffer, targetBlock, ref, "SFX_Books_And_Papers_Mailbox_Receive");
                     }
                 } else {

--- a/src/main/java/net/conczin/gui/MailComposeGui.java
+++ b/src/main/java/net/conczin/gui/MailComposeGui.java
@@ -5,7 +5,7 @@ import com.hypixel.hytale.component.Ref;
 import com.hypixel.hytale.component.Store;
 import com.hypixel.hytale.protocol.packets.interface_.CustomPageLifetime;
 import com.hypixel.hytale.protocol.packets.interface_.CustomUIEventBindingType;
-import com.hypixel.hytale.server.core.inventory.Inventory;
+import com.hypixel.hytale.server.core.inventory.InventoryComponent;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
 import com.hypixel.hytale.server.core.ui.DropdownEntryInfo;
 import com.hypixel.hytale.server.core.ui.LocalizableString;
@@ -64,11 +64,13 @@ public class MailComposeGui extends CodecDataInteractiveUIPage<MailComposeGui.Da
 
         if ("Send".equals(data.action)) {
             if (data.recipient != null) {
-                Inventory inventory = Utils.getInventory(ref);
-                ItemStack itemInHand = inventory.getActiveHotbarItem();
+                InventoryComponent.Hotbar hotbar = Utils.getHotbar(ref);
+                ItemStack itemInHand = hotbar != null ? hotbar.getActiveItem() : null;
                 MailboxResource mailboxResource = ref.getStore().getResource(MailboxResource.getResourceType());
                 mailboxResource.push(UUID.fromString(data.recipient), itemInHand);
-                inventory.getHotbar().replaceItemStackInSlot(inventory.getActiveHotbarSlot(), itemInHand, ItemStack.EMPTY);
+                if (hotbar != null && itemInHand != null) {
+                    hotbar.getInventory().replaceItemStackInSlot(hotbar.getActiveSlot(), itemInHand, ItemStack.EMPTY);
+                }
             }
             close();
         }

--- a/src/main/java/net/conczin/utils/Utils.java
+++ b/src/main/java/net/conczin/utils/Utils.java
@@ -7,8 +7,7 @@ import com.hypixel.hytale.math.util.ChunkUtil;
 import com.hypixel.hytale.protocol.BlockPosition;
 import com.hypixel.hytale.protocol.InteractionType;
 import com.hypixel.hytale.server.core.entity.UUIDComponent;
-import com.hypixel.hytale.server.core.entity.entities.Player;
-import com.hypixel.hytale.server.core.inventory.Inventory;
+import com.hypixel.hytale.server.core.inventory.InventoryComponent;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
 import com.hypixel.hytale.server.core.modules.block.components.ItemContainerBlock;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.Interaction;
@@ -35,11 +34,11 @@ public class Utils {
 
     public static <T> void setData(Ref<EntityStore> ref, BlockPosition block, String field, BuilderCodec<T> codec, T data) {
         if (block == null) {
-            Inventory inventory = getInventory(ref);
-            ItemStack itemInHand = inventory.getActiveHotbarItem();
-            if (itemInHand != null) {
+            InventoryComponent.Hotbar hotbar = getHotbar(ref);
+            ItemStack itemInHand = hotbar != null ? hotbar.getActiveItem() : null;
+            if (hotbar != null && itemInHand != null) {
                 ItemStack newItemInHand = itemInHand.withMetadata(field, codec, data);
-                inventory.getHotbar().replaceItemStackInSlot(inventory.getActiveHotbarSlot(), itemInHand, newItemInHand);
+                hotbar.getInventory().replaceItemStackInSlot(hotbar.getActiveSlot(), itemInHand, newItemInHand);
             }
         } else {
             World world = ref.getStore().getExternalData().getWorld();
@@ -57,8 +56,8 @@ public class Utils {
     public static <T> T getData(Ref<EntityStore> ref, BlockPosition block, String field, BuilderCodec<T> codec) {
         ItemStack stack;
         if (block == null) {
-            Inventory inventory = getInventory(ref);
-            stack = inventory.getActiveHotbarItem();
+            InventoryComponent.Hotbar hotbar = getHotbar(ref);
+            stack = hotbar != null ? hotbar.getActiveItem() : null;
         } else {
             World world = ref.getStore().getExternalData().getWorld();
             stack = getItemFromContainer(world, block, 0);
@@ -69,10 +68,8 @@ public class Utils {
         return codec.getDefaultValue();
     }
 
-    public static Inventory getInventory(Ref<EntityStore> ref) {
-        Player player = ref.getStore().getComponent(ref, Player.getComponentType());
-        assert player != null;
-        return player.getInventory();
+    public static InventoryComponent.Hotbar getHotbar(Ref<EntityStore> ref) {
+        return ref.getStore().getComponent(ref, InventoryComponent.Hotbar.getComponentType());
     }
 
 

--- a/src/main/java/net/conczin/utils/Utils.java
+++ b/src/main/java/net/conczin/utils/Utils.java
@@ -2,18 +2,25 @@ package net.conczin.utils;
 
 import com.hypixel.hytale.codec.builder.BuilderCodec;
 import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.math.util.ChunkUtil;
 import com.hypixel.hytale.protocol.BlockPosition;
 import com.hypixel.hytale.protocol.InteractionType;
 import com.hypixel.hytale.server.core.entity.UUIDComponent;
 import com.hypixel.hytale.server.core.entity.entities.Player;
 import com.hypixel.hytale.server.core.inventory.Inventory;
 import com.hypixel.hytale.server.core.inventory.ItemStack;
+import com.hypixel.hytale.server.core.modules.block.components.ItemContainerBlock;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.Interaction;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.RootInteraction;
 import com.hypixel.hytale.server.core.modules.interaction.interaction.config.server.OpenCustomUIInteraction;
 import com.hypixel.hytale.server.core.universe.world.World;
-import com.hypixel.hytale.server.core.universe.world.meta.state.ItemContainerState;
+import com.hypixel.hytale.server.core.universe.world.chunk.BlockChunk;
+import com.hypixel.hytale.server.core.universe.world.chunk.BlockComponentChunk;
+import com.hypixel.hytale.server.core.universe.world.chunk.section.BlockSection;
+import com.hypixel.hytale.server.core.universe.world.storage.ChunkStore;
 import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import com.hypixel.hytale.server.core.util.FillerBlockUtil;
 import net.conczin.gui.BookUISupplier;
 
 import java.lang.reflect.Field;
@@ -39,7 +46,7 @@ public class Utils {
             ItemStack stack = getItemFromContainer(world, block, 0);
             if (stack != null) {
                 ItemStack newStack = stack.withMetadata(field, codec, data);
-                ItemContainerState inventory = getInventory(world, block);
+                ItemContainerBlock inventory = getInventory(world, block);
                 if (inventory != null) {
                     inventory.getItemContainer().setItemStackForSlot((short) 0, newStack);
                 }
@@ -80,16 +87,46 @@ public class Utils {
         }
     }
 
-    public static ItemContainerState getInventory(World world, BlockPosition targetBlock) {
-        // noinspection deprecation
-        if (world.getState(targetBlock.x, targetBlock.y, targetBlock.z, true) instanceof ItemContainerState itemcontainerstate) {
-            return itemcontainerstate;
+    public static ItemContainerBlock getInventory(World world, BlockPosition targetBlock) {
+        int x = targetBlock.x;
+        int y = targetBlock.y;
+        int z = targetBlock.z;
+
+        ChunkStore chunkStore = world.getChunkStore();
+        Ref<ChunkStore> chunkRef = chunkStore.getChunkReference(ChunkUtil.indexChunkFromBlock(x, z));
+        if (chunkRef == null || !chunkRef.isValid()) {
+            return null;
         }
-        return null;
+
+        Store<ChunkStore> chunkStoreData = chunkStore.getStore();
+        BlockChunk blockChunk = chunkStoreData.getComponent(chunkRef, BlockChunk.getComponentType());
+        BlockComponentChunk blockComponentChunk = chunkStoreData.getComponent(chunkRef, BlockComponentChunk.getComponentType());
+        if (blockChunk == null || blockComponentChunk == null) {
+            return null;
+        }
+
+        BlockSection section = blockChunk.getSectionAtBlockY(y);
+        if (section == null) {
+            return null;
+        }
+
+        int filler = section.getFiller(x, y, z);
+        if (filler != 0) {
+            x -= FillerBlockUtil.unpackX(filler);
+            y -= FillerBlockUtil.unpackY(filler);
+            z -= FillerBlockUtil.unpackZ(filler);
+        }
+
+        Ref<ChunkStore> blockRef = blockComponentChunk.getEntityReference(ChunkUtil.indexBlockInColumn(x, y, z));
+        if (blockRef == null) {
+            return null;
+        }
+
+        return chunkStoreData.getComponent(blockRef, ItemContainerBlock.getComponentType());
     }
 
     public static ItemStack getItemFromContainer(World world, BlockPosition targetBlock, int slot) {
-        ItemContainerState inventory = getInventory(world, targetBlock);
+        ItemContainerBlock inventory = getInventory(world, targetBlock);
         if (inventory != null) {
             return inventory.getItemContainer().getItemStack((short) slot);
         }

--- a/src/main/resources/Server/Item/Items/Books_And_Papers_Lectern.json
+++ b/src/main/resources/Server/Item/Items/Books_And_Papers_Lectern.json
@@ -50,8 +50,6 @@
     "VariantRotation": "NESW",
     "ParticleColor": "#8B4513",
     "State": {
-      "Id": "container",
-      "Capacity": 1,
       "Definitions": {
         "CloseWindow": {
           "InteractionSoundEventId": "SFX_Chest_Wooden_Close"
@@ -61,8 +59,14 @@
         }
       }
     },
+    "BlockEntity": {
+      "Components": {
+        "ItemContainerBlock": {
+          "Capacity": 1
+        }
+      }
+    },
     "Interactions": {
-      "Primary": "Break_Container",
       "Use": {
         "Interactions": [
           {

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,18 +1,23 @@
 {
   "Group": "Conczin",
   "Name": "Books and Papers",
-  "Version": "0.0.1",
+  "Version": "1.2.0",
   "Description": "Various writable books, a mail system, and hidden lore across the world.",
   "Authors": [
     {
       "Name": "Conczin",
       "Email": "conczin@gmail.com",
       "Url": "https://conczin.net/"
+    },
+    {
+      "Name": "GlobalHive",
+      "Email": "support@globalhive.ch",
+      "Url": "https://globalhive.ch/"
     }
   ],
   "Website": "https://conczin.net/",
   "Main": "net.conczin.BooksAndPapers",
-  "ServerVersion": "2026.02.17-255364b8e",
+  "ServerVersion": "2026.03.26-89796e57b",
   "Dependencies": {},
   "OptionalDependencies": {},
   "DisabledByDefault": false,


### PR DESCRIPTION
## Summary

This PR updates the mod to use current Hytale server APIs in places that were relying on deprecated container and inventory access patterns.

## What Changed

- Replaced deprecated `ItemContainerState` usage with `ItemContainerBlock`
- Updated block container lookup to resolve the block entity through chunk data instead of reading deprecated world state container metadata
- Replaced deprecated `Inventory` wrapper usage with `InventoryComponent`-based access
- Switched hotbar item access to `InventoryComponent.Hotbar`
- Switched combined pickup/drop paths to `InventoryComponent.getCombined(..., InventoryComponent.HOTBAR_FIRST)`

## Why

The previous implementation depended on APIs marked for deprecation or removal. This change aligns the project with the newer server-side component model and reduces future breakage risk as the Hytale server code evolves.

## Notes

- This PR is focused on API migration only and does not intentionally change gameplay behavior
- Any remaining deprecation warnings are outside the scope of this migration